### PR TITLE
Fixed an issue that prevented updating the list of installed plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ ohmyzsh_users:
 ohmyzsh_config:
   - { regexp: '^ZSH_THEME="robbyrussell"$', line: 'ZSH_THEME="agnoster"'}
   - { regexp: '^# ENABLE_CORRECTION="true"$', line: 'ENABLE_CORRECTION="true"'}
-  - { regexp: '^plugins=\(git\)', line: 'plugins=({{ ohmyzsh_plugins }})'}
+  - { regexp: '^plugins=\(.*\)', line: 'plugins=({{ ohmyzsh_plugins }})'}
 
-ohmyzsh_plugins:  |
+ohmyzsh_plugins:  >-
   ansible
   chucknorris
   colored-man-pages

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,9 +7,9 @@ ohmyzsh_users:
 ohmyzsh_config:
   - { regexp: '^ZSH_THEME="robbyrussell"$', line: 'ZSH_THEME="agnoster"'}
   - { regexp: '^# ENABLE_CORRECTION="true"$', line: 'ENABLE_CORRECTION="true"'}
-  - { regexp: '^plugins=\(git\)', line: 'plugins=({{ ohmyzsh_plugins }})'}
+  - { regexp: '^plugins=\(.*\)', line: 'plugins=({{ ohmyzsh_plugins }})'}
 
-ohmyzsh_plugins:  |
+ohmyzsh_plugins:  >-
   ansible
   chucknorris
   colored-man-pages


### PR DESCRIPTION
Added two minor changes:

1. The regex pattern now matches **any** plugins as opposed to just the **git** plugin provided in the stock config. This allows users to simply update **ohmyzsh_plugins**  to makes changes to the list of installed plugins.

2. Replaced the YAML character **|** with **>-**. This collapses newlines into spaces and strips the trailing newline character. This prevents the regex pattern from breaking due to plugins being spread over multiple lines.